### PR TITLE
Update commit status request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-//
+# HelloWorldApp
+
+This repository uses GitHub Actions for build and test. The Actions results
+show up as **check runs**, not as **commit statuses**. The endpoint you tried:
+
+```
+GET /repos/{owner}/{repo}/commits/{ref}/status
+```
+
+returns **only** statuses created via the Statuses API. If nothing has posted a
+status for that commit, the response is still `200` but has
+`"total_count": 0` and `"statuses": []`, which can look like "not working".
+
+## Query commit statuses (legacy Statuses API)
+
+Use the full SHA and optional authentication to avoid rate limits:
+
+```
+curl \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  https://api.github.com/repos/miryamGSM/HelloWorldApp/commits/716683bc1e1ef7ae6fe020808adf46e667881cd5/status
+```
+
+## Query GitHub Actions results (Checks API)
+
+GitHub Actions publishes check runs. Use the Checks API instead:
+
+```
+curl \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/repos/miryamGSM/HelloWorldApp/commits/716683bc1e1ef7ae6fe020808adf46e667881cd5/check-runs"
+```
+
+## (Optional) Create a commit status
+
+If you want `/status` to return something, you must post a status:
+
+```
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  https://api.github.com/repos/miryamGSM/HelloWorldApp/statuses/716683bc1e1ef7ae6fe020808adf46e667881cd5 \
+  -d '{"state":"success","context":"ci/example","description":"Example status"}'
+```


### PR DESCRIPTION
Add README guidance to clarify why `/commits/{ref}/status` returns empty and how to query GitHub Actions results via the Checks API.

The `/commits/{ref}/status` endpoint only shows legacy Statuses API results. GitHub Actions publishes **check runs**, so the Checks API must be used to retrieve workflow outcomes.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b052ad77-bba7-4008-a72c-322e5b11c2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b052ad77-bba7-4008-a72c-322e5b11c2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

