### PR TITLE
Workflow coverage job issue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,13 +28,11 @@ jobs:
       - name: Run tests with coverage
         run: |
           dotnet test \
-            --no-build \
-            /p:CollectCoverage=true \
-            /p:CoverletOutput=./TestResults/ \
-            /p:CoverletOutputFormat=opencover
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./TestResults
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: "**/TestResults/coverage.opencover.xml"
+          files: "**/TestResults/*/coverage.cobertura.xml"
           fail_ci_if_error: true


### PR DESCRIPTION
Fixes coverage workflow by switching to `coverlet.collector` invocation and updating Codecov path to match its output.

The previous workflow used `coverlet.collector` but attempted to collect coverage using MSBuild properties meant for `coverlet.msbuild`, resulting in no coverage files being generated. This PR updates the `dotnet test` command to correctly use the `XPlat Code Coverage` collector and adjusts the Codecov action to find the resulting `cobertura.xml` file.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c79ef007-f23a-4391-81b6-d41a58fde132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c79ef007-f23a-4391-81b6-d41a58fde132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

